### PR TITLE
Re-deployment of komodo on jboss issue

### DIFF
--- a/komodoweb-deps/pom.xml
+++ b/komodoweb-deps/pom.xml
@@ -164,6 +164,16 @@
         <version>3.0</version>
       </dependency>
 
+      <!--
+        This is required but we need to downgrade to ensure
+        compatibility across both errai and the engine
+       -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>13.0.1</version>
+      </dependency>
+
       <dependency>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-core</artifactId>

--- a/komodoweb-distros/src/main/jbossas7/WEB-INF/web.xml
+++ b/komodoweb-distros/src/main/jbossas7/WEB-INF/web.xml
@@ -75,4 +75,7 @@
     <welcome-file>login.jsp</welcome-file>
   </welcome-file-list>
 
+  <listener>
+    <listener-class>org.komodo.web.backend.server.context.KomodoServerListener</listener-class>
+  </listener>
 </web-app>

--- a/komodoweb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/komodoweb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -72,8 +72,4 @@
   <welcome-file-list>
     <welcome-file>login.jsp</welcome-file>
   </welcome-file-list>
-
-  <listener>
-    <listener-class>org.komodo.web.backend.server.context.KomodoServerListener</listener-class>
-  </listener>
 </web-app>


### PR DESCRIPTION
* Redeploying the komodo-web war fails to shutdown modeshape correctly so
  the starting of modeshape causes an exception that the cache manager is
  already started

* Downgrades the guava dependency to a version 13, aligned to the version
  used in the komodo engine

* web.xml
 * Moves the context listener to the correct location for jboss to observe
   it properly